### PR TITLE
Make digdag-go-client work with Digdag 0.10.1 or later

### DIFF
--- a/digdag.go
+++ b/digdag.go
@@ -88,7 +88,6 @@ func (c *Client) NewRequest(method, spath string, ro *RequestOpts) (resp *http.R
 	if ro.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Accept-Encoding", "gzip")
 	req.Header.Set("User-Agent", c.UserAgent)
 
 	// Set custom headers


### PR DESCRIPTION
Digdag added support for response body compression from 0.10.1 and
returns gzipped response body when a client set "Accept-Encoding: gzip"
in the request header.
https://github.com/treasure-data/digdag/pull/591

digdag-go-client sets "Accept-Encoding: gzip" in the request header
but does not decode the gzipped response body, which causes any APIs
to return error below.

invalid character '\x1f' looking for beginning of value

This change makes digdag-go-client work with digdag 0.10.1 or later
by removing the explicit request of "Accept-Encoding: gzip"
and letting http.DefaultTransport request compression with an
"Accept-Encoding: gzip" request header and handle the gzipped
response body transparently.
https://pkg.go.dev/net/http#Transport.DisableCompression